### PR TITLE
Use dplyr 0.4.3.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,6 @@ Imports:
     DBI,
     RMSSQL,
     stringr,
-    dplyr
-Enhances: dplyr
+    dplyr (== 0.4.3)
+Enhances: dplyr (== 0.4.3)
 RoxygenNote: 5.0.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Microsoft SQL Server source driver for dplyr using the RMSSQL package
 
 requirements
 ===============
-
+    devtools::install_version("dplyr", version = "0.4.3")
     devtools::install_github("bescoto/RMSSQL")
     devtools::install_github("bescoto/dplyr.mssql") # this package
 


### PR DESCRIPTION
Fixes issue where installation fails due to new 0.5.0 release.
